### PR TITLE
Make multiple-evals on the same line work

### DIFF
--- a/sample.org
+++ b/sample.org
@@ -1,4 +1,4 @@
-# -*- my-http-status: 400; -*-
+# -*- my-http-status: 400; base-url: "https://httpbin.org" -*-
 
 * Custom function for later
   #+begin_src emacs-lisp
@@ -29,6 +29,8 @@
 
 * Embedded lisp variable
   GET https://httpbin.org/status/`my-http-status`
+* More than one embedded lisp variable
+  GET `base-url`/status/`my-http-status`
 
 * Embedded lisp function
   PUT https://httpbin.org/put

--- a/test/walkman-test.el
+++ b/test/walkman-test.el
@@ -58,7 +58,9 @@
     (funcall test "`(+ 1 2)`" '() "3")
     (funcall test "`(funcall (lambda () (- 500 100)))`" '() "400")
     (funcall test "`(version)`" '() (version))
-    (funcall test "(version)" '() "(version)")))
+    (funcall test "(version)" '() "(version)")
+    ;; should handle multiple replacements in the same string
+    (funcall test "`emacs-version`-`emacs-version`" '() (format "%s-%s" emacs-version emacs-version))))
 
 (ert-deftest walkman--test-parse-request ()
   (let ((request (with-temp-buffer

--- a/walkman.el
+++ b/walkman.el
@@ -140,7 +140,7 @@ QUOTED is the optional flag to quote or not headers."
 LOCAL-VARIABLES is the alist of local variables from original buffer."
   (save-excursion
     (goto-char (point-min))
-    (while (re-search-forward "`\\(.*\\)`" nil t)
+    (while (re-search-forward "`\\(.*?\\)`" nil t)
       (let* ((variable (car (read-from-string (match-string 1))))
              (local-value (assoc-default variable local-variables)))
         (replace-match (format "%s" (or local-value (eval variable))))))))


### PR DESCRIPTION
The eval code used a greedy regex that swallowed everything between the first and last '`'. Replacing it with a non-greedy one makes it work :-)

This is useful as I like to have a 'base-url' variable (to easily switch between our public site and local development) but occasionally also need to have other vars in the URL.

PS: thank you for walkman :-)