### PR TITLE
Make requests asynchronously

### DIFF
--- a/test/walkman-test.el
+++ b/test/walkman-test.el
@@ -23,9 +23,11 @@
     (should (equal (walkman-response-body response)
                    (with-temp-buffer
                      (insert "{
-  \"args\": {},
+  \"args\": {
+  },
   \"data\": \"\",
-  \"files\": {},
+  \"files\": {
+  },
   \"headers\": {
     \"Accept\": \"*/*\",
     \"Content-Length\": \"87\",
@@ -148,11 +150,15 @@
 
 (ert-deftest walkman--test-at-point ()
   (cl-letf (((symbol-function 'walkman--exec)
-             (lambda (args &optional keep-headers)
+             (lambda (args)
                (walkman-response--create :code 200 :status "OK" :headers '() :body ""))))
-    (with-temp-buffer
-      (insert-file-contents "test/sample-request")
-      (should (not (walkman-at-point))))))
+    (let ((response (with-temp-buffer
+                      (insert-file-contents "sample-request")
+                      (walkman-at-point))))
+      (should (equal (walkman-response-code response) 200))
+      (should (equal (walkman-response-status response) "OK"))
+      (should (equal (walkman-response-headers response) '()))
+      (should (equal (walkman-response-body response) "")))))
 
 ;; (ert "walkman--test-.*")
 


### PR DESCRIPTION
This commit changes requests from sync to async. This is especially
useful when using Emacs to both make the HTTP request (with `walkman`)
and with a terminal for local development. In such a scenario, we can't
let Emacs hang on the HTTP request, otherwise we can't access the
terminal.

To make this change I needed to change `call-process` to `make-process`.
Since the request now happens asynchronously, I needed to change the way
the response is parsed, which now happens inside a sentinel (which is
called once the process created by `make-process` ends).

Closes #7.