### PR TITLE
Change regex in form parsing to only replace first occurrence

### DIFF
--- a/test/sample-request
+++ b/test/sample-request
@@ -4,6 +4,7 @@
   - Content-Type: application/json
   :FORM:
   - type: document
+  - metadata: {"some": "json"}
   - file: [[/home/user/sample.jpg]]
   :END:
   #+begin_src json

--- a/test/walkman-test.el
+++ b/test/walkman-test.el
@@ -77,7 +77,7 @@
     (should (equal (walkman-request-url request) "https://httpbin.org/post"))
     (should (equal (walkman-request-headers request)
                    '("Accept: application/json" "Content-Type: application/json")))
-    (should (equal (walkman-request-form-headers request) '("type=document" "file=@/home/user/sample.jpg")))
+    (should (equal (walkman-request-form-headers request) '("type=document" "metadata={\"some\": \"json\"}" "file=@/home/user/sample.jpg")))
     (should (equal (walkman-request-body request) "{
   \"data\": {
     \"title\": \"Hello\",

--- a/walkman.el
+++ b/walkman.el
@@ -211,12 +211,12 @@ LOCAL-VARIABLES is the alist of local variables from original buffer."
                  (let ((link (car (org-element-map item 'link 'identity)))
                        (item (car (org-element-contents item))))
                    (replace-regexp-in-string
-                    ": *" "="
+                    "\\(: \\).*\\'" "="
                     (if link
                         (concat (buffer-substring-no-properties (org-element-property :begin item)
                                                                 (org-element-property :begin link))
                                 "@" (org-element-property :path link))
-                      (walkman--org-text item)))))))))))
+                      (walkman--org-text item)) nil nil 1)))))))))
 
 (defun walkman--extract-body (elements)
   "Extract the body out of an org section parsed into org ELEMENTS."


### PR DESCRIPTION
Currently when parsing `:FORM` headers, we're replacing every occurrence of `: ` with `=`. However, when the form header value also contains `:`, we're wrongly replacing it with `=` as well – for instance, when parsing an header that contains JSON object, we're replacing all of the `:` in the key-value syntax with `=`, thus producing invalid JSON.

This commit fixes that by only changing the first occurrence. This is done following the advice on the documentation for `replace-regexp-in-string` function.