### PR TITLE
parse optional args for curl commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The general structure is
 ```org
 * Request Title
   GET/POST/PUT/... URL
+  --curl-args value
   - Header1: value
   - Header2: value
   :FORM:
@@ -143,6 +144,14 @@ and run
        (lambda (status headers body)
          (pp (assoc 'url (json-read-from-string body))))
      #+end_src
+```
+
+### Request with optional curl args
+```org
+* Request with certs and key
+  GET https://httpbin.org/get
+  --key /users/foo/key.pem
+  --cert /users/foo/cert.pem
 ```
 
 ## Customization

--- a/test/sample-request
+++ b/test/sample-request
@@ -2,6 +2,8 @@
   POST https://httpbin.org/post
   - Accept: application/json
   - Content-Type: application/json
+  --key /home/user/key.pem
+  --cert /home/user/cert.pem
   :FORM:
   - type: document
   - metadata: {"some": "json"}


### PR DESCRIPTION
Based on https://github.com/abrochard/walkman/issues/16 suggestion, we can now add optional args to the curl command with this PR.

In the future, maybe we can define default args at the top to be able to use them on each request.

Let me know what you think!